### PR TITLE
Update Gravatar.php

### DIFF
--- a/src/Gravatar.php
+++ b/src/Gravatar.php
@@ -77,7 +77,7 @@ class Gravatar {
 
 		$this->setConfig(['fallback' => 404]);
 
-		$headers = get_headers($this->buildUrl());
+		$headers = @get_headers($this->buildUrl());
 
 		return (boolean) strpos($headers[0], '200');
 	}


### PR DESCRIPTION
Sometimes I code without an internet connection.
When this happens, the package returns an error due to the get_headers() PHP function, inside exists() function.

Adding a @ before function, exists() will return FALSE whenever the user is not connected to the internet. So solving the problem.

What do you think?