### PR TITLE
Fixed an issue where the fallback config failed to load.

### DIFF
--- a/src/Gravatar.php
+++ b/src/Gravatar.php
@@ -41,7 +41,7 @@ class Gravatar
 	/**
 	 * @var string|false
 	 */
-	private $fallback;
+	private $fallback = false;
 
 	/**
 	 * Override the default image fallback set in the config.


### PR DESCRIPTION
The fallback config isn't loading because on line 220 it checks `$this->fallback === false`. At that point it is still null, because it was never set. This sets it to false by default to allow fallbacks to work again.