### PR TITLE
Fix Typehint of Gravatar::get

### DIFF
--- a/src/Gravatar.php
+++ b/src/Gravatar.php
@@ -93,7 +93,7 @@ class Gravatar
 	 * Get the gravatar url
 	 *
 	 * @param string $email
-	 * @param string $configGroup
+	 * @param string|array|null $configGroup
 	 * @return string
 	 * @throws InvalidEmailException
 	 */


### PR DESCRIPTION
`\Creativeorange\Gravatar\Facades\Gravatar::get($email, $configGroup)`

$configGroup needs to match the type in `setConfig`, otherwise, the IDE will warn that there's a type mismatch and we can't set an array as an option.