### PR TITLE
Update Gravatar hashing to use sha256

### DIFF
--- a/config/gravatar.php
+++ b/config/gravatar.php
@@ -9,7 +9,7 @@ return [
 		'size'   => 80,
 
 		// the fallback image, can be a string or a url
-		// for more info, visit: http://en.gravatar.com/site/implement/images/#default-image
+		// for more info, visit: https://docs.gravatar.com/api/avatars/images/#default-image
 		'fallback' => 'mp',
 
 		// would you like to return a https://... image

--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,7 @@ Within your controllers or views, you can use
 this will return the URL to the gravatar image of the specified email address.
 In case of a non-existing gravatar, it will return return a URL to a placeholder image. 
 You can set the type of the placeholder in the configuration option `fallback`. 
-For more information, visit [gravatar.com](http://en.gravatar.com/site/implement/images/#default-image)
+For more information, visit [gravatar.com](https://docs.gravatar.com/api/avatars/images/#default-image)
 
 Alternatively, you can check for the existence of a gravatar image by using
 

--- a/src/Gravatar.php
+++ b/src/Gravatar.php
@@ -46,18 +46,18 @@ class Gravatar
 	/**
 	 * Override the default image fallback set in the config.
 	 * Can either be a public URL to an image or a valid themed image.
-	 * For more info, visit http://en.gravatar.com/site/implement/images/#default-image
+	 * For more info, visit https://docs.gravatar.com/api/avatars/images/#default-image
 	 *
 	 * @param string $fallback
 	 * @return $this
 	 */
 	public function fallback($fallback)
 	{
-		// Gravatar changed mm to mp. 
+		// Gravatar changed mm to mp.
 		// This way we make sure everything keeps working
 		if ($fallback === 'mm')
 			$fallback = 'mp';
-		
+
 		if (
 			filter_var($fallback, FILTER_VALIDATE_URL, FILTER_FLAG_PATH_REQUIRED)
 			|| in_array($fallback, array('mp', 'identicon', 'monsterid', 'wavatar', 'retro', 'robohash', 'blank'))
@@ -145,13 +145,13 @@ class Gravatar
 	}
 
 	/**
-	 * Helper function to md5 hash the email address
+	 * Helper function to sha256 hash the email address
 	 *
 	 * @return string
 	 */
 	private function hashEmail()
 	{
-		return md5(strtolower(trim($this->email)));
+		return hash('sha256', strtolower(trim($this->email)));
 	}
 
 	/**


### PR DESCRIPTION
Gravatar added support for both MD5 and SHA256, this PR migrates Gravatar's usage to the new sha256 hashing algorithm.

Source: https://docs.gravatar.com/api/avatars/php