### PR TITLE
Exists returning none boolean value

### DIFF
--- a/src/Gravatar.php
+++ b/src/Gravatar.php
@@ -86,7 +86,7 @@ class Gravatar
 
 		$headers = @get_headers($this->buildUrl());
 
-		return (bool) ($headers) ? strpos($headers[0], '200') : false;
+		return (bool) (($headers) ? strpos($headers[0], '200') : false);
 	}
 
 	/**


### PR DESCRIPTION
It looks like the exist function is returning the strpos not true/false.

I'm assuming the bool is being applied to the header value.

This is on 8.3.17

Just put brackets so the bool is applied to the result.